### PR TITLE
Ascendants should only follow other ascedants' degree

### DIFF
--- a/utils/inheritance.test.ts
+++ b/utils/inheritance.test.ts
@@ -202,6 +202,63 @@ test('Spouse, parents, bilateral, and unilateral siblings ', () => {
   expect(asFraction(result.unilateral[0].inheritance)).toBe('1/18')
 })
 
+test('Spouse, two grandparents and one sibling', () => {
+  const deceased = newDeceased({
+    spouse: [newPerson({ id: '3', name: 'Coniuge', alive: true, category: 'spouse' })],
+    parents: [
+      newPerson({
+        id: '2',
+        name: 'Mamma',
+        alive: false,
+        category: 'parents',
+        parents: [
+          newPerson({ id: '8', name: 'Nonna', alive: true, category: 'parents' }),
+          newPerson({ id: '9', name: 'Nonno', alive: true, category: 'parents' }),
+        ],
+      }),
+    ],
+    siblings: [newPerson({ id: '4', name: 'Fratello 1', alive: true, category: 'siblings' })],
+  })
+  const result = calculateInheritance(deceased)
+
+  expect(asFraction(result.spouse[0].inheritance)).toBe('2/3')
+  expect(asFraction(result.siblings[0].inheritance)).toBe('1/6')
+  expect(asFraction(result.parents[0].parents[0].inheritance)).toBe('1/12')
+  expect(asFraction(result.parents[0].parents[1].inheritance)).toBe('1/12')
+})
+
+test('Spouse, one grandparent and four siblings', () => {
+  // The spouse takes 2/3
+  // The grandparent has to have at least 1/4 of the remaning inheritance
+  // The rest goes to the siblings
+  const deceased = newDeceased({
+    spouse: [newPerson({ id: '3', name: 'Coniuge', alive: true, category: 'spouse' })],
+    parents: [
+      newPerson({
+        id: '2',
+        name: 'Mamma',
+        alive: false,
+        category: 'parents',
+        parents: [newPerson({ id: '8', name: 'Nonna', alive: true, category: 'parents' })],
+      }),
+    ],
+    siblings: [
+      newPerson({ id: '4', name: 'Fratello 1', alive: true, category: 'siblings' }),
+      newPerson({ id: '5', name: 'Sorella 1', alive: true, category: 'siblings' }),
+      newPerson({ id: '6', name: 'Sorella 2', alive: true, category: 'siblings' }),
+      newPerson({ id: '7', name: 'Fratello 2', alive: true, category: 'siblings' }),
+    ],
+  })
+  const result = calculateInheritance(deceased)
+
+  expect(asFraction(result.spouse[0].inheritance)).toBe('2/3')
+  expect(asFraction(result.siblings[0].inheritance)).toBe('1/16')
+  expect(asFraction(result.siblings[1].inheritance)).toBe('1/16')
+  expect(asFraction(result.siblings[2].inheritance)).toBe('1/16')
+  expect(asFraction(result.siblings[3].inheritance)).toBe('1/16')
+  expect(asFraction(result.parents[0].parents[0].inheritance)).toBe('1/12')
+})
+
 test('Two parents', () => {
   // Inheritance gets evenly divided between the two
   const deceased = newDeceased({
@@ -338,19 +395,23 @@ test('One parent and one sibling', () => {
   expect(asFraction(result.siblings[0].inheritance)).toBe('1/2')
 })
 
-test('Two parents and one sibling', () => {
+test('One grandparent and one sibling', () => {
   const deceased = newDeceased({
     parents: [
-      newPerson({ id: '2', name: 'Mamma', alive: true, category: 'parents' }),
-      newPerson({ id: '3', name: 'Papà', alive: true, category: 'parents' }),
+      newPerson({
+        id: '2',
+        name: 'Mamma',
+        alive: false,
+        category: 'parents',
+        parents: [newPerson({ id: '4', name: 'Nonna', alive: true, category: 'parents' })],
+      }),
     ],
-    siblings: [newPerson({ id: '4', name: 'Fratello', alive: true, category: 'siblings' })],
+    siblings: [newPerson({ id: '3', name: 'Fratello', alive: true, category: 'siblings' })],
   })
   const result = calculateInheritance(deceased)
 
-  expect(asFraction(result.parents[0].inheritance)).toBe('1/3')
-  expect(asFraction(result.parents[1].inheritance)).toBe('1/3')
-  expect(asFraction(result.siblings[0].inheritance)).toBe('1/3')
+  expect(asFraction(result.parents[0].parents[0].inheritance)).toBe('1/2')
+  expect(asFraction(result.siblings[0].inheritance)).toBe('1/2')
 })
 
 test('Two parents and one sibling', () => {

--- a/utils/inheritance.ts
+++ b/utils/inheritance.ts
@@ -144,7 +144,7 @@ const findInheritance = (total: number, current?: Person) => {
     current.inheritance = total
   }
 
-  if (children?.length) {
+  if (children?.length > 0) {
     // multiple children and spouse:    2/3/children and 1/3
     // multiple children and no spouse: 1/children   and 0
     let forChildren = spouse?.[0] ? ((total / 3) * 2) / children.length : total / children.length
@@ -169,12 +169,11 @@ const findInheritance = (total: number, current?: Person) => {
   let inheritance = {
     relatives: total,
     parents: 0,
-    siblingsTotal: 0,
     siblings: 0,
     unilateral: 0,
   }
 
-  if (spouse?.length) {
+  if (spouse?.length > 0) {
     // only spouse:                 1
     // spouse and other relatives : 2/3
     let forSpouse = numberRelatives > 0 ? (total / 3) * 2 : total
@@ -183,7 +182,7 @@ const findInheritance = (total: number, current?: Person) => {
     findInheritance(forSpouse, spouse[0])
   }
 
-  if (numberParents) {
+  if (numberParents > 0) {
     inheritance.parents = inheritance.relatives / numberRelatives
     // The parents receive at least half of the remaining inheritance
     if (inheritance.parents * numberParents < inheritance.relatives / 2) {
@@ -198,23 +197,25 @@ const findInheritance = (total: number, current?: Person) => {
       // If neither parents is alive but the grandparents are, they receive only 1 parent's worth
       if (parentsAlive?.length === 0) {
         inheritance.parents = inheritance.relatives / (1 + numberSiblings + numberUnilateral) / numberParents
+        if (inheritance.parents * numberParents < inheritance.relatives / 4) {
+          inheritance.parents = inheritance.relatives / 4 / numberParents
+        }
       }
       parents?.forEach((parent) => findInheritance(inheritance.parents, parent))
     }
+    inheritance.relatives -= inheritance.parents * numberParents
   }
 
-  if (numberSiblings + numberUnilateral) {
-    inheritance.siblingsTotal = inheritance.relatives - inheritance.parents * numberParents
-
+  if (numberSiblings + numberUnilateral > 0) {
     if (numberUnilateral === 0) {
       // If there are no unilateral siblings all goes the bilateral siblings
-      inheritance.siblings = inheritance.siblingsTotal / numberSiblings
+      inheritance.siblings = inheritance.relatives / numberSiblings
     } else if (numberSiblings === 0) {
       // If there are no bilateral siblings all goes to the unilateral siblings
-      inheritance.unilateral = inheritance.siblingsTotal / numberUnilateral
+      inheritance.unilateral = inheritance.relatives / numberUnilateral
     } else {
       // Otherwise an unilateral sibling gets 1/2 of what a bilateral one would get
-      inheritance.siblings = inheritance.siblingsTotal / (numberSiblings + numberUnilateral / 2)
+      inheritance.siblings = inheritance.relatives / (numberSiblings + numberUnilateral / 2)
       inheritance.unilateral = inheritance.siblings / 2
     }
 


### PR DESCRIPTION
Ascendants should not be removed even if someone's degree of kinship is lower than theirs.
The only way they can get removed is if another ascendant has a lower degree than them.

Grandparents should have at least 1/4 of the inheritance which is one parent's worth.