### PR TITLE
Change default root category to root

### DIFF
--- a/core/invertGraph.ts
+++ b/core/invertGraph.ts
@@ -17,7 +17,7 @@ export function defaultRoot(): Person {
     available: false,
     degree: 0,
     previous: null,
-    category: 'children',
+    category: 'root',
     relatives: [],
   }
 }

--- a/core/tests/inheritance.test.ts
+++ b/core/tests/inheritance.test.ts
@@ -96,6 +96,33 @@ test('Three children and one spouse', () => {
   expect(result['spouse']).toBe('1/3')
 })
 
+test('Three children, one dead but has two others and one spouse', () => {
+  // children get 2/3 of the total so 2/9 each
+  // grandchildren then get 1/9 each
+  // spouse gets 1/3 of the total
+  const list = {
+    ...newPerson({ id: 'spouse', category: 'spouse' }),
+    ...newDeceased(['first-child', 'second-child', 'third-child', 'spouse']),
+    ...newPerson({ id: 'first-child', category: 'children' }),
+    ...newPerson({ id: 'second-child', category: 'children' }),
+    ...newPerson({
+      id: 'third-child',
+      category: 'children',
+      available: false,
+      relatives: ['first-grandchild', 'second-grandchild'],
+    }),
+    ...newPerson({ id: 'first-grandchild', category: 'children' }),
+    ...newPerson({ id: 'second-grandchild', category: 'children' }),
+  }
+  const result = calculateInheritance(list)
+
+  expect(result['first-child']).toBe('2/9')
+  expect(result['second-child']).toBe('2/9')
+  expect(result['first-grandchild']).toBe('1/9')
+  expect(result['second-grandchild']).toBe('1/9')
+  expect(result['spouse']).toBe('1/3')
+})
+
 test('One child and parents, bilateral, or unilateral siblings ', () => {
   // Only the child should get the total
   const list = {

--- a/core/tests/invertedGraph.test.ts
+++ b/core/tests/invertedGraph.test.ts
@@ -9,7 +9,7 @@ test('Only one child', () => {
   // prettier-ignore
   expect(graph).toStrictEqual({
     'only-child': { id: list[0].id, name: list[0].name, available: list[0].available, degree: 1, category: 'children', relatives: [], previous: '0' },
-    '0': { id: '0', name: 'Defunto', available: false, degree: 0, category: 'children', relatives: ['only-child'], previous: null },
+    '0': { id: '0', name: 'Defunto', available: false, degree: 0, category: 'root', relatives: ['only-child'], previous: null },
   })
 })
 
@@ -24,7 +24,7 @@ test('Child and spouse', () => {
   expect(graph).toStrictEqual({
     '1': { id: list[0].id, name: list[0].name, available: list[0].available, degree: 1, category: 'children', relatives: [], previous: '0' },
     '2': { id: list[1].id, name: list[1].name, available: list[1].available, degree: 1, category: 'spouse', relatives: [], previous: '0' },
-    '0': { id: '0', name: 'Defunto', available: false, degree: 0, category: 'children', relatives: ['1', '2'], previous: null },
+    '0': { id: '0', name: 'Defunto', available: false, degree: 0, category: 'root', relatives: ['1', '2'], previous: null },
   })
 })
 
@@ -43,7 +43,7 @@ test('nested children', () => {
     '2': { id: list[1].id, name: list[1].name, available: list[1].available, degree: 2, category: 'children', relatives: ['3'], previous: '1' },
     '3': { id: list[2].id, name: list[2].name, available: list[2].available, degree: 3, category: 'children', relatives: ['4'], previous: '2' },
     '4': { id: list[3].id, name: list[3].name, available: list[3].available, degree: 4, category: 'children', relatives: [], previous: '3' },
-    '0': { id: '0', name: 'Defunto', available: false, degree: 0, category: 'children', relatives: ['1'], previous: null },
+    '0': { id: '0', name: 'Defunto', available: false, degree: 0, category: 'root', relatives: ['1'], previous: null },
   })
 })
 
@@ -62,7 +62,7 @@ test('siblings', () => {
     '2': { id: list[1].id, name: list[1].name, available: list[1].available, degree: 2, category: 'bilinear', relatives: [], previous: '0' },
     '3': { id: list[2].id, name: list[2].name, available: list[2].available, degree: 2, category: 'bilinear', relatives: [], previous: '0' },
     '4': { id: list[3].id, name: list[3].name, available: list[3].available, degree: 2, category: 'bilinear', relatives: [], previous: '0' },
-    '0': { id: '0', name: 'Defunto', available: false, degree: 0, category: 'children', relatives: ['1', '2', '3', '4'], previous: null },
+    '0': { id: '0', name: 'Defunto', available: false, degree: 0, category: 'root', relatives: ['1', '2', '3', '4'], previous: null },
   })
 })
 
@@ -77,6 +77,30 @@ test('other relatives', () => {
   expect(graph).toStrictEqual({
     '1': { id: list[0].id, name: list[0].name, available: list[0].available, degree: 3, category: 'others', relatives: [], previous: '0' },
     '2': { id: list[1].id, name: list[1].name, available: list[1].available, degree: 4, category: 'others', relatives: [], previous: '0' },
-    '0': { id: '0', name: 'Defunto', available: false, degree: 0, category: 'children', relatives: ['1', '2'], previous: null },
+    '0': { id: '0', name: 'Defunto', available: false, degree: 0, category: 'root', relatives: ['1', '2'], previous: null },
+  })
+})
+
+test('wife and children', () => {
+  const list: InvertedPerson[] = [
+    { available: true, id: '38', name: 'Emma', relatedTo: '', relation: 'coniuge' },
+    { available: true, id: '39', name: 'Renata', relatedTo: '', relation: 'figlio' },
+    { available: true, id: '40', name: 'Giorgia', relatedTo: '', relation: 'figlio' },
+    { available: true, id: '44', name: 'Elisa', relatedTo: '47', relation: 'nipote in linea retta' },
+    { available: true, id: '45', name: 'Francesca', relatedTo: '47', relation: 'nipote in linea retta' },
+    { available: false, id: '47', name: 'Luciano', relatedTo: '', relation: 'figlio' },
+  ]
+
+  const graph = invertGraph(defaultRoot(), list)
+
+  // prettier-ignore
+  expect(graph).toStrictEqual({
+    '0': { id: '0', name: 'Defunto', available: false, degree: 0, category: 'root', relatives: ['38', '39', "40", "47"], previous: null },
+    '38': { id: list[0].id, name: list[0].name, available: list[0].available, degree: 1, category: "spouse", relatives: [], previous: '0' },
+    '39': { id: list[1].id, name: list[1].name, available: list[1].available, degree: 1, category: "children", relatives: [], previous: '0' },
+    '40': { id: list[2].id, name: list[2].name, available: list[2].available, degree: 1, category: "children", relatives: [], previous: '0' },
+    '44': { id: list[3].id, name: list[3].name, available: list[3].available, degree: 2, category: "children", relatives: [], previous: '47' },
+    '45': { id: list[4].id, name: list[4].name, available: list[4].available, degree: 2, category: "children", relatives: [], previous: '47' },
+    '47': { id: list[5].id, name: list[5].name, available: list[5].available, degree: 1, category: "children", relatives: ['44', '45'], previous: '0' },
   })
 })


### PR DESCRIPTION
The default root for the inverted graph was still using `children` as their category instead of `root`